### PR TITLE
Implement admin announcements carousel

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -375,3 +375,15 @@ footer {
 [data-theme="dark"] .docs-card a {
   color: var(--charcoal);
 }
+
+/* ---------- Announcements Carousel ---------- */
+#alertsCarousel { position: relative; margin-block: 2rem; }
+.announce-card {
+  background:#fff;border-radius:8px;padding:1rem;font-weight:600;
+  box-shadow:0 2px 6px rgba(0,0,0,.05);display:flex;align-items:center;
+  justify-content:center;text-align:center;min-height:80px;
+}
+.announce-card.info { background:#2563eb;color:#fff; }
+.announce-card.warning { background:#e37b40;color:#fff; }
+.announce-card.danger { background:#dc2626;color:#fff; }
+

--- a/data/alerts.json
+++ b/data/alerts.json
@@ -1,4 +1,5 @@
-{
-  "message": "High fire danger today.",
-  "level": "danger"
-}
+[
+  { "message": "High fire danger today.", "level": "danger" },
+  { "message": "Board meeting moved to Monday 7pm.", "level": "info" },
+  { "message": "Marina closed for maintenance Friday.", "level": "warning" }
+]

--- a/index.html
+++ b/index.html
@@ -43,6 +43,15 @@
   </div>
 </section>
 
+<!-- ANNOUNCEMENTS -->
+<section class="wrapper" id="announcements">
+  <h2 class="section-title reveal">Announcements</h2>
+  <div id="alertsCarousel" class="swiper">
+    <div class="swiper-wrapper"></div>
+    <div class="swiper-pagination"></div>
+  </div>
+</section>
+
 <!-- WELCOME -->
 <main class="wrapper reveal" id="welcome">
   <h2>Welcome to Lake Almanor Country Club!</h2>
@@ -146,6 +155,8 @@
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" defer></script>
 <!-- Events Script -->
 <script src="js/events-carousel.js" defer></script>
+<!-- Announcements Script -->
+<script src="js/announcements-carousel.js" defer></script>
 <!-- Toast Messages Script -->
 <script src="js/alert-toast.js" defer></script>
 <!-- Gate Alert Script -->

--- a/js/announcements-carousel.js
+++ b/js/announcements-carousel.js
@@ -1,0 +1,28 @@
+window.addEventListener('DOMContentLoaded', async () => {
+  const wrapper = document.querySelector('#alertsCarousel .swiper-wrapper');
+  if (!wrapper) return;
+
+  try {
+    const res = await fetch('data/alerts.json');
+    let alerts = await res.json();
+    if (!Array.isArray(alerts)) alerts = [alerts];
+
+    wrapper.innerHTML = alerts.map(a => `
+      <div class="swiper-slide">
+        <article class="announce-card ${a.level || 'info'}">
+          <p>${a.message}</p>
+        </article>
+      </div>
+    `).join('');
+
+    new Swiper('#alertsCarousel', {
+      slidesPerView: 1,
+      loop: true,
+      autoplay: { delay: 5000, disableOnInteraction: false },
+      pagination: { el: '#alertsCarousel .swiper-pagination', clickable: true }
+    });
+  } catch (err) {
+    console.error('Announcements error', err);
+    wrapper.innerHTML = '<p style="grid-column:1/-1;text-align:center">Announcements unavailable.</p>';
+  }
+});

--- a/roadmap.json
+++ b/roadmap.json
@@ -129,7 +129,7 @@
     {
       "id": "admin-announcements-feed",
       "title": "Admin Announcements Carousel",
-      "status": "todo",
+      "status": "complete",
       "description": "Build a carousel driven by `alerts.json` so admins can post news, bulletins, or warnings.",
       "dependsOn": ["real-time-gate-alerts"]
     },

--- a/service-worker.js
+++ b/service-worker.js
@@ -16,6 +16,7 @@ const CORE_ASSETS = [
   '/lacc-dev/css/style.css',
   '/lacc-dev/js/main.js',
   '/lacc-dev/js/events-carousel.js',
+  '/lacc-dev/js/announcements-carousel.js',
   '/lacc-dev/js/amenity-map.js',
   '/lacc-dev/js/alert-toast.js',
   '/lacc-dev/js/gate-alert.js',


### PR DESCRIPTION
## Summary
- show announcements in a new Swiper carousel
- style announcement cards with level colors
- fetch data from updated `alerts.json`
- cache new script in service worker
- mark "Admin Announcements Carousel" roadmap task complete

## Testing
- `node --check js/announcements-carousel.js`
- `node -e "const fs=require('fs');const a=JSON.parse(fs.readFileSync('data/alerts.json'));console.log(Array.isArray(a),a.length);"`

------
https://chatgpt.com/codex/tasks/task_e_6887d376ffd8832db70270625b3628d6