### PR TITLE
Fix script tag for amenity map

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,7 +133,7 @@
   <h2 class="section-title">Interactive Amenity Map</h2>
   <div id="amenityMap" role="application" aria-label="Interactive amenity map" style="height: 500px;"></div>
 </section>
-<script src="js/amenity-map.js" defer></script>
+<script type="module" src="js/amenity-map.js"></script>
 
 
 <!-- DARK MODE TOGGLE -->


### PR DESCRIPTION
## Summary
- use `type="module"` on the amenity map script

## Testing
- `npx --version` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688806ede1b4832db0d316725419f29b