### PR TITLE
Fix gate alert caching

### DIFF
--- a/js/gate-alert.js
+++ b/js/gate-alert.js
@@ -16,7 +16,7 @@ function makeToast(txt, level = 'danger') {
 
 async function checkGate() {
   try {
-    const res = await fetch('data/alerts.json');
+    const res = await fetch('data/alerts.json', { cache: 'no-store' });
     if (!res.ok) return;
     const { status, gate, until, message } = await res.json();
 


### PR DESCRIPTION
## Summary
- fetch gate alerts JSON without caching

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68880b1bcaf8832d8aa6b01a8af969f0