### PR TITLE
Fix gate alert path and document python deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+node_modules/
+calendar/events/*.ics

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # lacc-dev
 Dev Repo For LACC
+
+## Development
+
+Some utilities require Python packages.  Install them with:
+
+```bash
+pip install -r requirements.txt
+```
+
+The `calendar/gen_ics.py` script uses `icalendar`, `pytz` and `PyYAML` to
+generate `.ics` files from `events.yml`.

--- a/calendar/gen_ics.py
+++ b/calendar/gen_ics.py
@@ -5,8 +5,10 @@ from icalendar import Calendar, Event
 import pytz
 import yaml  # pip install pyyaml
 
-# 1) Load your events list
-with open("events.yml") as f:
+BASE_DIR = os.path.dirname(__file__)
+
+# 1) Load your events list relative to this file
+with open(os.path.join(BASE_DIR, "events.yml")) as f:
     events = yaml.safe_load(f)
 
 # 2) For each event, build an .ics
@@ -18,7 +20,7 @@ for ev in events:
     ical = Event()
     uid = ev["id"] + "@lakealmanorcountryclub.com"
     ical.add("UID", uid)
-    ical.add("DTSTAMP", datetime.now(pytz.UTC))
+    ical.add("DTSTAMP", datetime.fromisoformat(ev["start"]).astimezone(pytz.UTC))
     ical.add("DTSTART", datetime.fromisoformat(ev["start"]))
     ical.add("DTEND",   datetime.fromisoformat(ev["end"]))
     ical.add("SUMMARY", ev["title"])
@@ -26,7 +28,7 @@ for ev in events:
     ical.add("LOCATION", ev["location"])
     cal.add_component(ical)
 
-    # 3) Write to calendar/<id>.ics
-    path = os.path.join("events", f"{ev['id']}.ics")
+    # 3) Write to calendar/<id>.ics in this folder
+    path = os.path.join(BASE_DIR, "events", f"{ev['id']}.ics")
     with open(path, "wb") as fout:
         fout.write(cal.to_ical())

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- Google Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Playfair+Display:wght@600&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&amp;family=Playfair+Display:wght@600&amp;display=swap" rel="stylesheet" />
 
   <link rel="stylesheet" href="css/style.css" />
 

--- a/js/gate-alert.js
+++ b/js/gate-alert.js
@@ -16,7 +16,7 @@ function makeToast(txt, level = 'danger') {
 
 async function checkGate() {
   try {
-    const res = await fetch('data/alerts.json', { cache: 'no-store' });
+    const res = await fetch('data/gate-status.json', { cache: 'no-store' });
     if (!res.ok) return;
     const { status, gate, until, message } = await res.json();
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+icalendar
+pytz
+PyYAML


### PR DESCRIPTION
## Summary
- add `.gitignore` and Python requirements
- fix gate alert to fetch correct file
- update README with instructions
- fix HTML ampersands
- make calendar script path-aware

## Testing
- `pip install -r requirements.txt`
- `python3 -m py_compile calendar/gen_ics.py`
- `node --check js/gate-alert.js`
- `tidy -eq index.html`


------
https://chatgpt.com/codex/tasks/task_e_68880e9191e8832d8f5d519ba8758ab9